### PR TITLE
Add as_slice functions on VecMap and or_default function on Entry

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,27 @@ impl<K, V> VecMap<K, V> {
             _phantom: Default::default(),
         }
     }
+
+    /// Returns a slice containing all keys in the map.
+    ///
+    /// The order is arbitrary and may change when items are inserted or removed.
+    pub fn keys_as_slice(&self) -> &[K] {
+        &self.keys
+    }
+
+    /// Returns a slice containing all values in the map.
+    ///
+    /// The order is arbitrary and may change when items are inserted or removed.
+    pub fn values_as_slice(&self) -> &[V] {
+        &self.values
+    }
+
+    /// Returns a mutable slice containing all values in the map.
+    ///
+    /// The order is arbitrary and may change when items are inserted or removed.
+    pub fn values_as_slice_mut(&mut self) -> &mut [V] {
+        &mut self.values
+    }
 }
 
 impl<K: PartialEq, V> Default for VecMap<K, V> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,6 +417,16 @@ impl<'a, K, V> Entry<'a, K, V> {
             Vacant(entry) => entry.insert(default()),
         }
     }
+
+    /// Ensures that the entry is occupied by inserting the default value if it is vacant.
+    ///
+    /// Returns a mutable reference to the entry's value.
+    pub fn or_default(self) -> &'a mut V
+    where
+        V: Default,
+    {
+        self.or_insert_with(Default::default)
+    }
 }
 
 impl<'a, K, V> OccupiedEntry<'a, K, V> {


### PR DESCRIPTION
Thanks for the library! I added a few functions which I found useful when I was using it:

Added to VecMap:

- `.keys_as_slice()`
- `.values_as_slice()`
- `.values_as_slice_mut()`

I think the ability to have these slice functions at all is a great feature of VecMap.

Added to Entry:

- `.or_default()`

Just to make life marginally easier.